### PR TITLE
Update mest and mspgist code to PG version REL_18_BETA1

### DIFF
--- a/.github/workflows/mest-check.yml
+++ b/.github/workflows/mest-check.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pg: [17]
+        pg: [18]
     name: PostgreSQL ${{ matrix.pg }}
     runs-on: ubuntu-latest
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.o
 *.so
+*.bc
 .cache
 .deps
 build

--- a/mest--1.0.sql
+++ b/mest--1.0.sql
@@ -95,7 +95,7 @@ DEFAULT FOR TYPE anymultirange USING mgist AS
     FUNCTION    6   range_gist_picksplit(internal, internal),
     FUNCTION    7   range_gist_same(anyrange, anyrange, internal),
     FUNCTION    10  multirange_mest_options(internal),
-    FUNCTION    12  multirange_mest_extract(internal, internal, internal);
+    FUNCTION    13  multirange_mest_extract(internal, internal, internal);
     -- FUNCTION    13  multirange_mgist_extract_query(internal, internal, internal);
 
 /******************************************************************************
@@ -327,7 +327,7 @@ DEFAULT FOR TYPE path USING mgist AS
     FUNCTION    6   gist_box_picksplit(internal, internal),
     FUNCTION    7   gist_box_same(box, box, internal),
     FUNCTION    10  mest_path_options(internal),
-    FUNCTION    12  mest_path_extract(internal, internal, internal);
+    FUNCTION    13  mest_path_extract(internal, internal, internal);
 
 /******************************************************************************
  * Multi-Entry Quad-Tree for path types using MSPGiST

--- a/src/mgist/mgist.h
+++ b/src/mgist/mgist.h
@@ -21,9 +21,9 @@
 /*
  * amproc indexes for Multi-Entry GiST indexes.
  */
-#define MGIST_EXTRACTVALUE_PROC     12
-#define MGIST_EXTRACTQUERY_PROC     13
-#define MGISTNProcs                 13
+#define MGIST_EXTRACTVALUE_PROC     13
+#define MGIST_EXTRACTQUERY_PROC     14
+#define MGISTNProcs                 14
 
 /*
  * GISTSTATE: information needed for any GiST index operation

--- a/src/mgist/mgistbuild.c
+++ b/src/mgist/mgistbuild.c
@@ -273,7 +273,7 @@ mgistbuild(Relation heap, Relation index, IndexInfo *indexInfo)
 		/* Scan the table, adding all tuples to the tuplesort */
 		reltuples = table_index_build_scan(heap, index, indexInfo, true, true,
 										   mgistSortedBuildCallback,
-										   (void *) &mebuildstate, NULL);
+										   &mebuildstate, NULL);
 
 		/*
 		 * Perform the sort and build index pages.
@@ -312,7 +312,7 @@ mgistbuild(Relation heap, Relation index, IndexInfo *indexInfo)
 		/* Scan the table, inserting all the tuples to the index. */
 		reltuples = table_index_build_scan(heap, index, indexInfo, true, true,
 										   mgistBuildCallback,
-										   (void *) &mebuildstate, NULL);
+										   &mebuildstate, NULL);
 
 		/*
 		 * If buffering was used, flush out all the tuples that are still in
@@ -656,10 +656,12 @@ mgistInitBuffering(MGISTBuildState *mebuildstate)
 	itupMinSize = (Size) MAXALIGN(sizeof(IndexTupleData));
 	for (i = 0; i < index->rd_att->natts; i++)
 	{
-		if (TupleDescAttr(index->rd_att, i)->attlen < 0)
+		CompactAttribute *attr = TupleDescCompactAttr(index->rd_att, i);
+
+		if (attr->attlen < 0)
 			itupMinSize += VARHDRSZ;
 		else
-			itupMinSize += TupleDescAttr(index->rd_att, i)->attlen;
+			itupMinSize += attr->attlen;
 	}
 
 	/* Calculate average and maximal number of index tuples which fit to page */

--- a/src/mgist/mgistget.c
+++ b/src/mgist/mgistget.c
@@ -751,6 +751,8 @@ mgistgettuple(IndexScanDesc scan, ScanDirection dir)
 		so->tidisttable = gtidisttable_create(so->queueCxt, 128, so);
 
 		pgstat_count_index_scan(scan->indexRelation);
+		if (scan->instrument)
+			scan->instrument->nsearches++;
 
 		so->firstCall = false;
 		so->curPageData = so->nPageData = 0;
@@ -876,6 +878,8 @@ mgistgetbitmap(IndexScanDesc scan, TIDBitmap *tbm)
 		return 0;
 
 	pgstat_count_index_scan(scan->indexRelation);
+	if (scan->instrument)
+		scan->instrument->nsearches++;
 
 	/* Begin the scan by processing the root page */
 	so->curPageData = so->nPageData = 0;

--- a/src/mgist/mgistscan.c
+++ b/src/mgist/mgistscan.c
@@ -242,8 +242,7 @@ mgistrescan(IndexScanDesc scan, ScanKey key, int nkeys,
 				fn_extras[i] = scan->keyData[i].sk_func.fn_extra;
 		}
 
-		memmove(scan->keyData, key,
-				scan->numberOfKeys * sizeof(ScanKeyData));
+		memcpy(scan->keyData, key, scan->numberOfKeys * sizeof(ScanKeyData));
 
 		/*
 		 * Modify the scan key so that the Consistent method is called for all
@@ -298,8 +297,7 @@ mgistrescan(IndexScanDesc scan, ScanKey key, int nkeys,
 				fn_extras[i] = scan->orderByData[i].sk_func.fn_extra;
 		}
 
-		memmove(scan->orderByData, orderbys,
-				scan->numberOfOrderBys * sizeof(ScanKeyData));
+		memcpy(scan->orderByData, orderbys, scan->numberOfOrderBys * sizeof(ScanKeyData));
 
 		so->orderByTypes = (Oid *) palloc(scan->numberOfOrderBys * sizeof(Oid));
 

--- a/src/mgist/mgistutil.c
+++ b/src/mgist/mgistutil.c
@@ -21,6 +21,7 @@
 #include "common/pg_prng.h"
 #include "storage/indexfsm.h"
 #include "utils/float.h"
+#include "utils/fmgrprotos.h"
 #include "utils/lsyscache.h"
 #include "utils/rel.h"
 #include "utils/snapmgr.h"
@@ -1056,4 +1057,57 @@ gistGetFakeLSN(Relation rel)
 		Assert(rel->rd_rel->relpersistence == RELPERSISTENCE_UNLOGGED);
 		return GetFakeLSNForUnloggedRel();
 	}
+}
+
+/*
+ * This is a stratnum support function for GiST opclasses that use the
+ * RT*StrategyNumber constants.
+ */
+Datum
+gist_stratnum_common(PG_FUNCTION_ARGS)
+{
+	CompareType cmptype = PG_GETARG_INT32(0);
+
+	switch (cmptype)
+	{
+		case COMPARE_EQ:
+			PG_RETURN_UINT16(RTEqualStrategyNumber);
+		case COMPARE_LT:
+			PG_RETURN_UINT16(RTLessStrategyNumber);
+		case COMPARE_LE:
+			PG_RETURN_UINT16(RTLessEqualStrategyNumber);
+		case COMPARE_GT:
+			PG_RETURN_UINT16(RTGreaterStrategyNumber);
+		case COMPARE_GE:
+			PG_RETURN_UINT16(RTGreaterEqualStrategyNumber);
+		case COMPARE_OVERLAP:
+			PG_RETURN_UINT16(RTOverlapStrategyNumber);
+		case COMPARE_CONTAINED_BY:
+			PG_RETURN_UINT16(RTContainedByStrategyNumber);
+		default:
+			PG_RETURN_UINT16(InvalidStrategy);
+	}
+}
+
+/*
+ * Returns the opclass's private stratnum used for the given compare type.
+ *
+ * Calls the opclass's GIST_STRATNUM_PROC support function, if any,
+ * and returns the result.
+ * Returns InvalidStrategy if the function is not defined.
+ */
+StrategyNumber
+gisttranslatecmptype(CompareType cmptype, Oid opfamily)
+{
+	Oid			funcid;
+	Datum		result;
+
+	/* Check whether the function is provided. */
+	funcid = get_opfamily_proc(opfamily, ANYOID, ANYOID, GIST_STRATNUM_PROC);
+	if (!OidIsValid(funcid))
+		return InvalidStrategy;
+
+	/* Ask the translation function */
+	result = OidFunctionCall1Coll(funcid, InvalidOid, Int32GetDatum(cmptype));
+	return DatumGetUInt16(result);
 }

--- a/src/mgist/mgistvacuum.c
+++ b/src/mgist/mgistvacuum.c
@@ -22,6 +22,7 @@
 #include "miscadmin.h"
 #include "storage/indexfsm.h"
 #include "storage/lmgr.h"
+#include "storage/read_stream.h"
 #include "utils/memutils.h"
 
 /* Working state needed by gistbulkdelete */
@@ -44,8 +45,7 @@ typedef struct
 
 static void gistvacuumscan(IndexVacuumInfo *info, IndexBulkDeleteResult *stats,
 						   IndexBulkDeleteCallback callback, void *callback_state);
-static void gistvacuumpage(GistVacState *vstate, BlockNumber blkno,
-						   BlockNumber orig_blkno);
+static void gistvacuumpage(GistVacState *vstate, Buffer buffer);
 static void gistvacuum_delete_empty_pages(IndexVacuumInfo *info,
 										  GistVacState *vstate);
 static bool gistdeletepage(IndexVacuumInfo *info, IndexBulkDeleteResult *stats,
@@ -129,8 +129,9 @@ gistvacuumscan(IndexVacuumInfo *info, IndexBulkDeleteResult *stats,
 	GistVacState vstate;
 	BlockNumber num_pages;
 	bool		needLock;
-	BlockNumber blkno;
 	MemoryContext oldctx;
+	BlockRangeReadStreamPrivate p;
+	ReadStream *stream = NULL;
 
 	/*
 	 * Reset fields that track information about the entire index now.  This
@@ -208,7 +209,20 @@ gistvacuumscan(IndexVacuumInfo *info, IndexBulkDeleteResult *stats,
 	 */
 	needLock = !RELATION_IS_LOCAL(rel);
 
-	blkno = GIST_ROOT_BLKNO;
+	p.current_blocknum = GIST_ROOT_BLKNO;
+	/*
+	 * It is safe to use batchmode as block_range_read_stream_cb takes no
+	 * locks.
+	 */
+	stream = read_stream_begin_relation(READ_STREAM_MAINTENANCE |
+										READ_STREAM_FULL |
+										READ_STREAM_USE_BATCHING,
+										info->strategy,
+										rel,
+										MAIN_FORKNUM,
+										block_range_read_stream_cb,
+										&p,
+										0);
 	for (;;)
 	{
 		/* Get the current relation length */
@@ -219,12 +233,36 @@ gistvacuumscan(IndexVacuumInfo *info, IndexBulkDeleteResult *stats,
 			UnlockRelationForExtension(rel, ExclusiveLock);
 
 		/* Quit if we've scanned the whole relation */
-		if (blkno >= num_pages)
+		if (p.current_blocknum >= num_pages)
 			break;
-		/* Iterate over pages, then loop back to recheck length */
-		for (; blkno < num_pages; blkno++)
-			gistvacuumpage(&vstate, blkno, blkno);
+
+		p.last_exclusive = num_pages;
+
+		/* Iterate over pages, then loop back to recheck relation length */
+		while (true)
+		{
+			Buffer		buf;
+
+			/* call vacuum_delay_point while not holding any buffer lock */
+			vacuum_delay_point(false);
+
+			buf = read_stream_next_buffer(stream, NULL);
+
+			if (!BufferIsValid(buf))
+				break;
+
+			gistvacuumpage(&vstate, buf);
+		}
+
+		/*
+		 * We have to reset the read stream to use it again. After returning
+		 * InvalidBuffer, the read stream API won't invoke our callback again
+		 * until the stream has been reset.
+		 */
+		read_stream_reset(stream);
 	}
+
+	read_stream_end(stream);
 
 	/*
 	 * If we found any recyclable pages (and recorded them in the FSM), then
@@ -260,33 +298,31 @@ gistvacuumscan(IndexVacuumInfo *info, IndexBulkDeleteResult *stats,
 /*
  * gistvacuumpage --- VACUUM one page
  *
- * This processes a single page for gistbulkdelete().  In some cases we
- * must go back and re-examine previously-scanned pages; this routine
- * recurses when necessary to handle that case.
- *
- * blkno is the page to process.  orig_blkno is the highest block number
- * reached by the outer gistvacuumscan loop (the same as blkno, unless we
- * are recursing to re-examine a previous page).
+ * This processes a single page for gistbulkdelete(). `buffer` contains the
+ * page to process. In some cases we must go back and reexamine
+ * previously-scanned pages; this routine recurses when necessary to handle
+ * that case.
  */
 static void
-gistvacuumpage(GistVacState *vstate, BlockNumber blkno, BlockNumber orig_blkno)
+gistvacuumpage(GistVacState *vstate, Buffer buffer)
 {
 	IndexVacuumInfo *info = vstate->info;
 	IndexBulkDeleteCallback callback = vstate->callback;
 	void	   *callback_state = vstate->callback_state;
 	Relation	rel = info->index;
-	Buffer		buffer;
+	BlockNumber orig_blkno = BufferGetBlockNumber(buffer);
 	Page		page;
 	BlockNumber recurse_to;
 
+	/*
+	 * orig_blkno is the highest block number reached by the outer
+	 * gistvacuumscan() loop. This will be the same as blkno unless we are
+	 * recursing to reexamine a previous page.
+	 */
+	BlockNumber blkno = orig_blkno;
+
 restart:
 	recurse_to = InvalidBlockNumber;
-
-	/* call vacuum_delay_point while not holding any buffer lock */
-	vacuum_delay_point();
-
-	buffer = ReadBufferExtended(rel, MAIN_FORKNUM, blkno, RBM_NORMAL,
-								info->strategy);
 
 	/*
 	 * We are not going to stay here for a long time, aggressively grab an
@@ -450,6 +486,12 @@ restart:
 	if (recurse_to != InvalidBlockNumber)
 	{
 		blkno = recurse_to;
+
+		/* check for vacuum delay while not holding any buffer lock */
+		vacuum_delay_point(false);
+
+		buffer = ReadBufferExtended(rel, MAIN_FORKNUM, blkno, RBM_NORMAL,
+									info->strategy);
 		goto restart;
 	}
 }

--- a/src/mspgist/mspgdoinsert.c
+++ b/src/mspgist/mspgdoinsert.c
@@ -296,8 +296,8 @@ addLeafTuple(Relation index, SpGistState *state, SpGistLeafTuple leafTuple,
 		int			flags;
 
 		XLogBeginInsert();
-		XLogRegisterData((char *) &xlrec, sizeof(xlrec));
-		XLogRegisterData((char *) leafTuple, leafTuple->size);
+		XLogRegisterData(&xlrec, sizeof(xlrec));
+		XLogRegisterData(leafTuple, leafTuple->size);
 
 		flags = REGBUF_STANDARD;
 		if (xlrec.newPage)
@@ -533,12 +533,12 @@ moveLeafs(Relation index, SpGistState *state,
 		xlrec.nodeI = parent->node;
 
 		XLogBeginInsert();
-		XLogRegisterData((char *) &xlrec, SizeOfSpgxlogMoveLeafs);
-		XLogRegisterData((char *) toDelete,
+		XLogRegisterData(&xlrec, SizeOfSpgxlogMoveLeafs);
+		XLogRegisterData(toDelete,
 						 sizeof(OffsetNumber) * nDelete);
-		XLogRegisterData((char *) toInsert,
+		XLogRegisterData(toInsert,
 						 sizeof(OffsetNumber) * nInsert);
-		XLogRegisterData((char *) leafdata, leafptr - leafdata);
+		XLogRegisterData(leafdata, leafptr - leafdata);
 
 		XLogRegisterBuffer(0, current->buffer, REGBUF_STANDARD);
 		XLogRegisterBuffer(1, nbuf, REGBUF_STANDARD | (xlrec.newPage ? REGBUF_WILL_INIT : 0));
@@ -1366,15 +1366,15 @@ doPickSplit(Relation index, SpGistState *state,
 		XLogBeginInsert();
 
 		xlrec.nInsert = nToInsert;
-		XLogRegisterData((char *) &xlrec, SizeOfSpgxlogPickSplit);
+		XLogRegisterData(&xlrec, SizeOfSpgxlogPickSplit);
 
-		XLogRegisterData((char *) toDelete,
+		XLogRegisterData(toDelete,
 						 sizeof(OffsetNumber) * xlrec.nDelete);
-		XLogRegisterData((char *) toInsert,
+		XLogRegisterData(toInsert,
 						 sizeof(OffsetNumber) * xlrec.nInsert);
-		XLogRegisterData((char *) leafPageSelect,
+		XLogRegisterData(leafPageSelect,
 						 sizeof(uint8) * xlrec.nInsert);
-		XLogRegisterData((char *) innerTuple, innerTuple->size);
+		XLogRegisterData(innerTuple, innerTuple->size);
 		XLogRegisterData(leafdata, leafptr - leafdata);
 
 		/* Old leaf page */
@@ -1560,8 +1560,8 @@ spgAddNodeAction(Relation index, SpGistState *state,
 			XLogRecPtr	recptr;
 
 			XLogBeginInsert();
-			XLogRegisterData((char *) &xlrec, sizeof(xlrec));
-			XLogRegisterData((char *) newInnerTuple, newInnerTuple->size);
+			XLogRegisterData(&xlrec, sizeof(xlrec));
+			XLogRegisterData(newInnerTuple, newInnerTuple->size);
 
 			XLogRegisterBuffer(0, current->buffer, REGBUF_STANDARD);
 
@@ -1686,8 +1686,8 @@ spgAddNodeAction(Relation index, SpGistState *state,
 			if (xlrec.parentBlk == 2)
 				XLogRegisterBuffer(2, parent->buffer, REGBUF_STANDARD);
 
-			XLogRegisterData((char *) &xlrec, sizeof(xlrec));
-			XLogRegisterData((char *) newInnerTuple, newInnerTuple->size);
+			XLogRegisterData(&xlrec, sizeof(xlrec));
+			XLogRegisterData(newInnerTuple, newInnerTuple->size);
 
 			recptr = XLogInsert(RM_SPGIST_ID, XLOG_SPGIST_ADD_NODE);
 
@@ -1869,9 +1869,9 @@ spgSplitNodeAction(Relation index, SpGistState *state,
 		XLogRecPtr	recptr;
 
 		XLogBeginInsert();
-		XLogRegisterData((char *) &xlrec, sizeof(xlrec));
-		XLogRegisterData((char *) prefixTuple, prefixTuple->size);
-		XLogRegisterData((char *) postfixTuple, postfixTuple->size);
+		XLogRegisterData(&xlrec, sizeof(xlrec));
+		XLogRegisterData(prefixTuple, prefixTuple->size);
+		XLogRegisterData(postfixTuple, postfixTuple->size);
 
 		XLogRegisterBuffer(0, current->buffer, REGBUF_STANDARD);
 		if (newBuffer != InvalidBuffer)
@@ -1975,7 +1975,7 @@ mspgdoinsert(Relation index, SpGistState *state,
 	{
 		if (!isnulls[i])
 		{
-			if (TupleDescAttr(leafDescriptor, i)->attlen == -1)
+			if (TupleDescCompactAttr(leafDescriptor, i)->attlen == -1)
 				leafDatums[i] = PointerGetDatum(PG_DETOAST_DATUM(datums[i]));
 			else
 				leafDatums[i] = datums[i];

--- a/src/mspgist/mspginsert.c
+++ b/src/mspgist/mspginsert.c
@@ -167,7 +167,7 @@ mspgbuild(Relation heap, Relation index, IndexInfo *indexInfo)
 											  ALLOCSET_DEFAULT_SIZES);
 
 	reltuples = table_index_build_scan(heap, index, indexInfo, true, true,
-									   mspgistBuildCallback, (void *) &buildstate,
+									   mspgistBuildCallback, &buildstate,
 									   NULL);
 
 	MemoryContextDelete(buildstate.tmpCtx);

--- a/src/mspgist/mspgscan.c
+++ b/src/mspgist/mspgscan.c
@@ -428,16 +428,14 @@ mspgrescan(IndexScanDesc scan, ScanKey scankey, int nscankeys,
 
 	/* copy scankeys into local storage */
 	if (scankey && scan->numberOfKeys > 0)
-		memmove(scan->keyData, scankey,
-				scan->numberOfKeys * sizeof(ScanKeyData));
+		memcpy(scan->keyData, scankey, scan->numberOfKeys * sizeof(ScanKeyData));
 
 	/* initialize order-by data if needed */
 	if (orderbys && scan->numberOfOrderBys > 0)
 	{
 		int			i;
 
-		memmove(scan->orderByData, orderbys,
-				scan->numberOfOrderBys * sizeof(ScanKeyData));
+		memcpy(scan->orderByData, orderbys, scan->numberOfOrderBys * sizeof(ScanKeyData));
 
 		for (i = 0; i < scan->numberOfOrderBys; i++)
 		{
@@ -467,6 +465,8 @@ mspgrescan(IndexScanDesc scan, ScanKey scankey, int nscankeys,
 
 	/* count an indexscan for stats */
 	pgstat_count_index_scan(scan->indexRelation);
+	if (scan->instrument)
+		scan->instrument->nsearches++;
 }
 
 void
@@ -968,7 +968,7 @@ redirect:
 
 			if (SpGistPageIsLeaf(page))
 			{
-				/* Page is a leaf - that is, all it's tuples are heap items */
+				/* Page is a leaf - that is, all its tuples are heap items */
 				OffsetNumber max = PageGetMaxOffsetNumber(page);
 
 				if (SpGistBlockIsRoot(blkno))

--- a/src/mspgist/mspgutils.c
+++ b/src/mspgist/mspgutils.c
@@ -54,6 +54,9 @@ mspghandler(PG_FUNCTION_ARGS)
 	amroutine->amoptsprocnum = SPGIST_OPTIONS_PROC;
 	amroutine->amcanorder = false;
 	amroutine->amcanorderbyop = true;
+	amroutine->amcanhash = false;
+	amroutine->amconsistentequality = false;
+	amroutine->amconsistentordering = false;
 	amroutine->amcanbackward = false;
 	amroutine->amcanunique = false;
 	amroutine->amcanmulticol = false;
@@ -80,6 +83,7 @@ mspghandler(PG_FUNCTION_ARGS)
 	amroutine->amvacuumcleanup = spgvacuumcleanup;
 	amroutine->amcanreturn = spgcanreturn;
 	amroutine->amcostestimate = spgcostestimate;
+	amroutine->amgettreeheight = NULL;
 	amroutine->amoptions = spgoptions;
 	amroutine->amproperty = spgproperty;
 	amroutine->ambuildphasename = NULL;
@@ -95,6 +99,8 @@ mspghandler(PG_FUNCTION_ARGS)
 	amroutine->amestimateparallelscan = NULL;
 	amroutine->aminitparallelscan = NULL;
 	amroutine->amparallelrescan = NULL;
+	amroutine->amtranslatestrategy = NULL;
+	amroutine->amtranslatecmptype = NULL;
 
 	PG_RETURN_POINTER(amroutine);
 }

--- a/src/mspgist/mspgvacuum.c
+++ b/src/mspgist/mspgvacuum.c
@@ -25,6 +25,7 @@
 #include "storage/bufmgr.h"
 #include "storage/indexfsm.h"
 #include "storage/lmgr.h"
+#include "storage/read_stream.h"
 #include "utils/snapmgr.h"
 
 
@@ -380,14 +381,14 @@ vacuumLeafPage(spgBulkDeleteState *bds, Relation index, Buffer buffer,
 
 		STORE_STATE(&bds->spgstate, xlrec.stateSrc);
 
-		XLogRegisterData((char *) &xlrec, SizeOfSpgxlogVacuumLeaf);
+		XLogRegisterData(&xlrec, SizeOfSpgxlogVacuumLeaf);
 		/* sizeof(xlrec) should be a multiple of sizeof(OffsetNumber) */
-		XLogRegisterData((char *) toDead, sizeof(OffsetNumber) * xlrec.nDead);
-		XLogRegisterData((char *) toPlaceholder, sizeof(OffsetNumber) * xlrec.nPlaceholder);
-		XLogRegisterData((char *) moveSrc, sizeof(OffsetNumber) * xlrec.nMove);
-		XLogRegisterData((char *) moveDest, sizeof(OffsetNumber) * xlrec.nMove);
-		XLogRegisterData((char *) chainSrc, sizeof(OffsetNumber) * xlrec.nChain);
-		XLogRegisterData((char *) chainDest, sizeof(OffsetNumber) * xlrec.nChain);
+		XLogRegisterData(toDead, sizeof(OffsetNumber) * xlrec.nDead);
+		XLogRegisterData(toPlaceholder, sizeof(OffsetNumber) * xlrec.nPlaceholder);
+		XLogRegisterData(moveSrc, sizeof(OffsetNumber) * xlrec.nMove);
+		XLogRegisterData(moveDest, sizeof(OffsetNumber) * xlrec.nMove);
+		XLogRegisterData(chainSrc, sizeof(OffsetNumber) * xlrec.nChain);
+		XLogRegisterData(chainDest, sizeof(OffsetNumber) * xlrec.nChain);
 
 		XLogRegisterBuffer(0, buffer, REGBUF_STANDARD);
 
@@ -465,9 +466,9 @@ vacuumLeafRoot(spgBulkDeleteState *bds, Relation index, Buffer buffer)
 		/* Prepare WAL record */
 		STORE_STATE(&bds->spgstate, xlrec.stateSrc);
 
-		XLogRegisterData((char *) &xlrec, SizeOfSpgxlogVacuumRoot);
+		XLogRegisterData(&xlrec, SizeOfSpgxlogVacuumRoot);
 		/* sizeof(xlrec) should be a multiple of sizeof(OffsetNumber) */
-		XLogRegisterData((char *) toDelete,
+		XLogRegisterData(toDelete,
 						 sizeof(OffsetNumber) * xlrec.nDelete);
 
 		XLogRegisterBuffer(0, buffer, REGBUF_STANDARD);
@@ -600,8 +601,8 @@ vacuumRedirectAndPlaceholder(Relation index, Relation heaprel, Buffer buffer)
 
 		XLogBeginInsert();
 
-		XLogRegisterData((char *) &xlrec, SizeOfSpgxlogVacuumRedirect);
-		XLogRegisterData((char *) itemToPlaceholder,
+		XLogRegisterData(&xlrec, SizeOfSpgxlogVacuumRedirect);
+		XLogRegisterData(itemToPlaceholder,
 						 sizeof(OffsetNumber) * xlrec.nToPlaceholder);
 
 		XLogRegisterBuffer(0, buffer, REGBUF_STANDARD);
@@ -618,17 +619,12 @@ vacuumRedirectAndPlaceholder(Relation index, Relation heaprel, Buffer buffer)
  * Process one page during a bulkdelete scan
  */
 static void
-spgvacuumpage(spgBulkDeleteState *bds, BlockNumber blkno)
+spgvacuumpage(spgBulkDeleteState *bds, Buffer buffer)
 {
 	Relation	index = bds->info->index;
-	Buffer		buffer;
+	BlockNumber blkno = BufferGetBlockNumber(buffer);
 	Page		page;
 
-	/* call vacuum_delay_point while not holding any buffer lock */
-	vacuum_delay_point();
-
-	buffer = ReadBufferExtended(index, MAIN_FORKNUM, blkno,
-								RBM_NORMAL, bds->info->strategy);
 	LockBuffer(buffer, BUFFER_LOCK_EXCLUSIVE);
 	page = (Page) BufferGetPage(buffer);
 
@@ -704,7 +700,7 @@ spgprocesspending(spgBulkDeleteState *bds)
 			continue;			/* ignore already-done items */
 
 		/* call vacuum_delay_point while not holding any buffer lock */
-		vacuum_delay_point();
+		vacuum_delay_point(false);
 
 		/* examine the referenced page */
 		blkno = ItemPointerGetBlockNumber(&pitem->tid);
@@ -805,8 +801,9 @@ spgvacuumscan(spgBulkDeleteState *bds)
 {
 	Relation	index = bds->info->index;
 	bool		needLock;
-	BlockNumber num_pages,
-				blkno;
+	BlockNumber num_pages;
+	BlockRangeReadStreamPrivate p;
+	ReadStream *stream = NULL;
 
 	/* Finish setting up spgBulkDeleteState */
 	initSpGistState(&bds->spgstate, index);
@@ -824,6 +821,20 @@ spgvacuumscan(spgBulkDeleteState *bds)
 
 	/* We can skip locking for new or temp relations */
 	needLock = !RELATION_IS_LOCAL(index);
+	p.current_blocknum = SPGIST_METAPAGE_BLKNO + 1;
+	/*
+	 * It is safe to use batchmode as block_range_read_stream_cb takes no
+	 * locks.
+	 */
+	stream = read_stream_begin_relation(READ_STREAM_MAINTENANCE |
+										READ_STREAM_FULL |
+										READ_STREAM_USE_BATCHING,
+										bds->info->strategy,
+										index,
+										MAIN_FORKNUM,
+										block_range_read_stream_cb,
+										&p,
+										0);
 
 	/*
 	 * The outer loop iterates over all index pages except the metapage, in
@@ -833,7 +844,6 @@ spgvacuumscan(spgBulkDeleteState *bds)
 	 * delete some deletable tuples.  See more extensive comments about this
 	 * in btvacuumscan().
 	 */
-	blkno = SPGIST_METAPAGE_BLKNO + 1;
 	for (;;)
 	{
 		/* Get the current relation length */
@@ -844,17 +854,40 @@ spgvacuumscan(spgBulkDeleteState *bds)
 			UnlockRelationForExtension(index, ExclusiveLock);
 
 		/* Quit if we've scanned the whole relation */
-		if (blkno >= num_pages)
+		if (p.current_blocknum >= num_pages)
 			break;
+
+		p.last_exclusive = num_pages;
+
 		/* Iterate over pages, then loop back to recheck length */
-		for (; blkno < num_pages; blkno++)
+		while (true)
 		{
-			spgvacuumpage(bds, blkno);
+			Buffer		buf;
+
+			/* call vacuum_delay_point while not holding any buffer lock */
+			vacuum_delay_point(false);
+
+			buf = read_stream_next_buffer(stream, NULL);
+
+			if (!BufferIsValid(buf))
+				break;
+
+			spgvacuumpage(bds, buf);
+
 			/* empty the pending-list after each page */
 			if (bds->pendingList != NULL)
 				spgprocesspending(bds);
 		}
+
+		/*
+		 * We have to reset the read stream to use it again. After returning
+		 * InvalidBuffer, the read stream API won't invoke our callback again
+		 * until the stream has been reset.
+		 */
+		read_stream_reset(stream);
 	}
+
+	read_stream_end(stream);
 
 	/* Propagate local lastUsedPages cache to metablock */
 	SpGistUpdateMetaPage(index);

--- a/src/mspgist/mspgvalidate.c
+++ b/src/mspgist/mspgvalidate.c
@@ -19,7 +19,6 @@
 #include "catalog/pg_amop.h"
 #include "catalog/pg_amproc.h"
 #include "catalog/pg_opclass.h"
-#include "catalog/pg_opfamily.h"
 #include "catalog/pg_type.h"
 #include "utils/builtins.h"
 #include "utils/lsyscache.h"
@@ -46,8 +45,6 @@ mspgvalidate(Oid opclassoid)
 	Oid			opcintype;
 	Oid			opckeytype;
 	char	   *opclassname;
-	HeapTuple	familytup;
-	Form_pg_opfamily familyform;
 	char	   *opfamilyname;
 	CatCList   *proclist,
 			   *oprlist;
@@ -73,12 +70,7 @@ mspgvalidate(Oid opclassoid)
 	opclassname = NameStr(classform->opcname);
 
 	/* Fetch opfamily information */
-	familytup = SearchSysCache1(OPFAMILYOID, ObjectIdGetDatum(opfamilyoid));
-	if (!HeapTupleIsValid(familytup))
-		elog(ERROR, "cache lookup failed for operator family %u", opfamilyoid);
-	familyform = (Form_pg_opfamily) GETSTRUCT(familytup);
-
-	opfamilyname = NameStr(familyform->opfname);
+	opfamilyname = get_opfamily_name(opfamilyoid, false);
 
 	/* Fetch all operators and support functions of the opfamily */
 	oprlist = SearchSysCacheList1(AMOPSTRATEGY, ObjectIdGetDatum(opfamilyoid));
@@ -325,7 +317,6 @@ mspgvalidate(Oid opclassoid)
 
 	ReleaseCatCacheList(proclist);
 	ReleaseCatCacheList(oprlist);
-	ReleaseSysCache(familytup);
 	ReleaseSysCache(classtup);
 
 	return result;

--- a/src/text_mspgist.c
+++ b/src/text_mspgist.c
@@ -427,7 +427,7 @@ spg_text_inner_consistent(PG_FUNCTION_ARGS)
 {
 	spgInnerConsistentIn *in = (spgInnerConsistentIn *) PG_GETARG_POINTER(0);
 	spgInnerConsistentOut *out = (spgInnerConsistentOut *) PG_GETARG_POINTER(1);
-	bool		collate_is_c = lc_collate_is_c(PG_GET_COLLATION());
+	bool		collate_is_c = pg_newlocale_from_collation(PG_GET_COLLATION())->collate_is_c;
 	text	   *reconstructedValue;
 	text	   *reconstrText;
 	int			maxReconstrLen;


### PR DESCRIPTION
This only updates the mest code, the mobilitydb-mest and postgis-mest code have not been updated and might not work yet for the latest versions of MobilityDB and PostGIS. This will be fixed in upcoming PRs.